### PR TITLE
Add PathsFromFieldNumbers helper function

### DIFF
--- a/examples_test.go
+++ b/examples_test.go
@@ -85,3 +85,20 @@ func ExampleFilter_reuse_mask() {
 	fmt.Println(users)
 	// Output: [name:"name 1" name:"name 2"]
 }
+
+// ExamplePathsFromFieldNumbers illustrates how to convert protobuf field numbers to field paths.
+// This is useful when you have field numbers from the protobuf schema and need to convert them
+// to field paths for use with field masks.
+func ExamplePathsFromFieldNumbers() {
+	user := &testproto.User{}
+
+	// Convert field numbers to field paths.
+	// Field 1 is "user_id", field 2 is "name"
+	paths := fmutils.PathsFromFieldNumbers(user, 1, 2)
+	fmt.Println("Field numbers:", []int{1, 2})
+	fmt.Println("Paths:", paths)
+
+	// Output:
+	// Field numbers: [1 2]
+	// Paths: [user_id name]
+}

--- a/fmutils.go
+++ b/fmutils.go
@@ -246,3 +246,32 @@ func isValid(fd protoreflect.FieldDescriptor, val protoreflect.Value) bool {
 	}
 	return true
 }
+
+// PathsFromFieldNumbers converts protobuf field numbers to field paths for the given message.
+//
+// This function takes a protobuf message and a list of field numbers, and
+// returns a slice of field paths (field names) corresponding to those numbers.
+//
+// Field numbers that don't exist in the message descriptor are skipped.
+//
+// If no field numbers are provided, returns nil.
+//
+// Example:
+//
+//	// For a message with fields: name (field 1), age (field 2), address (field 3)
+//	paths := PathsFromFieldNumbers(msg, 1, 2)
+//	// Returns: ["name", "age"]
+func PathsFromFieldNumbers(msg proto.Message, fieldNumbers ...int) []string {
+	if len(fieldNumbers) == 0 {
+		return nil
+	}
+	paths := make([]string, 0, len(fieldNumbers))
+	descriptor := msg.ProtoReflect().Descriptor()
+	for _, n := range fieldNumbers {
+		field := descriptor.Fields().ByNumber(protoreflect.FieldNumber(n))
+		if field != nil {
+			paths = append(paths, field.TextName())
+		}
+	}
+	return paths
+}


### PR DESCRIPTION
Hi!

Firstly, thanks for the great work on this library!

I was wondering if you would be interested in merging this PR and adding the function to the library ?

The `PathsFromFieldNumbers` is based off of it's [Java counterpart](https://protobuf.dev/reference/java/api-docs/com/google/protobuf/util/FieldMaskUtil.html#fromFieldNumbers-java.lang.Class-int...-). I use it, and would love to have it available in Go as well.

Since your library is focused on Protobuf field masks, I'm thinking it's the right place for it.

Let met know :)

I've added unit tests & an example as well.