### PR TITLE
feat: add Dockerfile & Justfile recipe to build protobuf

### DIFF
--- a/Dockerfile.generate
+++ b/Dockerfile.generate
@@ -1,0 +1,25 @@
+# syntax=docker/dockerfile:1
+FROM golang:1.25-bookworm AS builder
+
+ARG PROTOC_VERSION=31.0
+ARG PROTOC_GEN_GO_VERSION=1.36.6
+
+WORKDIR /src
+
+# Install protoc.
+RUN apt-get update \
+    && apt-get install -y curl unzip \
+    && rm -rf /var/lib/apt/lists/* \
+    && curl -sSL -o /tmp/protoc.zip https://github.com/protocolbuffers/protobuf/releases/download/v${PROTOC_VERSION}/protoc-${PROTOC_VERSION}-linux-x86_64.zip \
+    && unzip /tmp/protoc.zip -d /usr/local \
+    && rm /tmp/protoc.zip
+
+# Install the Go code generator.
+RUN go install google.golang.org/protobuf/cmd/protoc-gen-go@v${PROTOC_GEN_GO_VERSION}
+
+# Copy the proto and generate the Go output.
+COPY testproto/testproto.proto testproto.proto
+RUN protoc --proto_path=. --go_out=. --go_opt=paths=source_relative testproto.proto
+
+FROM scratch AS artifact
+COPY --from=builder /src/testproto.pb.go /testproto/testproto.pb.go

--- a/Justfile
+++ b/Justfile
@@ -1,4 +1,0 @@
-# Generate the Go protobuf using the Docker build (writes pb file to repo root).
-protogen:
-	docker build --output type=local,dest=. --file Dockerfile.generate .
-	@ls -l testproto/testproto.pb.go

--- a/Justfile
+++ b/Justfile
@@ -1,0 +1,4 @@
+# Generate the Go protobuf using the Docker build (writes pb file to repo root).
+protogen:
+	docker build --output type=local,dest=. --file Dockerfile.generate .
+	@ls -l testproto/testproto.pb.go

--- a/build-protobuf.sh
+++ b/build-protobuf.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+docker build --output type=local,dest=. --file Dockerfile.generate .
+
+ls -l testproto/testproto.pb.go


### PR DESCRIPTION
Hi again, another PR to add a simple way to generate the Go Protobuf code.

I use a Docker image to generate the Go code (using `protoc` and `protoc-gen-go`), and created a Justfile recipe to easily execute it (`just protogen`).

Let me know if you prefer to use a Makefile.