### PR TITLE
fix: allow setting optional scalars to their default values

### DIFF
--- a/fmutils_test.go
+++ b/fmutils_test.go
@@ -1249,6 +1249,84 @@ func TestOverwrite(t *testing.T) {
 				},
 			},
 		},
+		{
+			name:  "overwrite optional bool from true to false",
+			paths: []string{"optional_bool"},
+			src: &testproto.Options{
+				OptionalBool: proto.Bool(false),
+			},
+			dest: &testproto.Options{
+				OptionalBool: proto.Bool(true),
+			},
+			want: &testproto.Options{
+				OptionalBool: proto.Bool(false),
+			},
+		},
+		{
+			name:  "overwrite optional bool from false to true",
+			paths: []string{"optional_bool"},
+			src: &testproto.Options{
+				OptionalBool: proto.Bool(true),
+			},
+			dest: &testproto.Options{
+				OptionalBool: proto.Bool(false),
+			},
+			want: &testproto.Options{
+				OptionalBool: proto.Bool(true),
+			},
+		},
+		{
+			name:  "overwrite optional bool from nil to false",
+			paths: []string{"optional_bool"},
+			src: &testproto.Options{
+				OptionalBool: proto.Bool(false),
+			},
+			dest: &testproto.Options{
+				OptionalBool: nil,
+			},
+			want: &testproto.Options{
+				OptionalBool: proto.Bool(false),
+			},
+		},
+		{
+			name:  "clear optional bool from true to nil",
+			paths: []string{"optional_bool"},
+			src: &testproto.Options{
+				OptionalBool: nil,
+			},
+			dest: &testproto.Options{
+				OptionalBool: proto.Bool(true),
+			},
+			want: &testproto.Options{
+				OptionalBool: nil,
+			},
+		},
+		{
+			name:  "overwrite optional int to zero",
+			paths: []string{"optional_int"},
+			src: &testproto.Options{
+				OptionalInt: proto.Int32(0),
+			},
+			dest: &testproto.Options{
+				OptionalInt: proto.Int32(42),
+			},
+			want: &testproto.Options{
+				OptionalInt: proto.Int32(0),
+			},
+		},
+		{
+			name:  "overwrite optional string to empty",
+			paths: []string{"optional_string"},
+			src: &testproto.Options{
+				OptionalString: proto.String(""),
+			},
+			dest: &testproto.Options{
+				OptionalString: proto.String("hello"),
+			},
+			want: &testproto.Options{
+				OptionalString: proto.String(""),
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/testproto/testproto.pb.go
+++ b/testproto/testproto.pb.go
@@ -346,6 +346,7 @@ type Options struct {
 	OptionalInt    *int32                 `protobuf:"varint,2,opt,name=optional_int,json=optionalInt,proto3,oneof" json:"optional_int,omitempty"`
 	OptionalPhoto  *Photo                 `protobuf:"bytes,3,opt,name=optional_photo,json=optionalPhoto,proto3,oneof" json:"optional_photo,omitempty"`
 	OptionalAttr   *Attribute             `protobuf:"bytes,4,opt,name=optional_attr,json=optionalAttr,proto3,oneof" json:"optional_attr,omitempty"`
+	OptionalBool   *bool                  `protobuf:"varint,5,opt,name=optional_bool,json=optionalBool,proto3,oneof" json:"optional_bool,omitempty"`
 	unknownFields  protoimpl.UnknownFields
 	sizeCache      protoimpl.SizeCache
 }
@@ -406,6 +407,13 @@ func (x *Options) GetOptionalAttr() *Attribute {
 		return x.OptionalAttr
 	}
 	return nil
+}
+
+func (x *Options) GetOptionalBool() bool {
+	if x != nil && x.OptionalBool != nil {
+		return *x.OptionalBool
+	}
+	return false
 }
 
 type Profile struct {
@@ -761,16 +769,18 @@ const file_testproto_proto_rawDesc = "" +
 	"\x06number\x18\x01 \x01(\tR\x06number\x12\x16\n" +
 	"\x06street\x18\x02 \x01(\tR\x06street\x12\x1f\n" +
 	"\vpostal_code\x18\x03 \x01(\tR\n" +
-	"postalCode\"\xa7\x02\n" +
+	"postalCode\"\xe3\x02\n" +
 	"\aOptions\x12,\n" +
 	"\x0foptional_string\x18\x01 \x01(\tH\x00R\x0eoptionalString\x88\x01\x01\x12&\n" +
 	"\foptional_int\x18\x02 \x01(\x05H\x01R\voptionalInt\x88\x01\x01\x12<\n" +
 	"\x0eoptional_photo\x18\x03 \x01(\v2\x10.testproto.PhotoH\x02R\roptionalPhoto\x88\x01\x01\x12>\n" +
-	"\roptional_attr\x18\x04 \x01(\v2\x14.testproto.AttributeH\x03R\foptionalAttr\x88\x01\x01B\x12\n" +
+	"\roptional_attr\x18\x04 \x01(\v2\x14.testproto.AttributeH\x03R\foptionalAttr\x88\x01\x01\x12(\n" +
+	"\roptional_bool\x18\x05 \x01(\bH\x04R\foptionalBool\x88\x01\x01B\x12\n" +
 	"\x10_optional_stringB\x0f\n" +
 	"\r_optional_intB\x11\n" +
 	"\x0f_optional_photoB\x10\n" +
-	"\x0e_optional_attr\"\xf3\x03\n" +
+	"\x0e_optional_attrB\x10\n" +
+	"\x0e_optional_bool\"\xf3\x03\n" +
 	"\aProfile\x12#\n" +
 	"\x04user\x18\x01 \x01(\v2\x0f.testproto.UserR\x04user\x12&\n" +
 	"\x05photo\x18\x02 \x01(\v2\x10.testproto.PhotoR\x05photo\x12)\n" +

--- a/testproto/testproto.proto
+++ b/testproto/testproto.proto
@@ -38,6 +38,7 @@ message Options {
   optional int32 optional_int = 2;
   optional Photo optional_photo = 3;
   optional Attribute optional_attr = 4;
+  optional bool optional_bool = 5;
 }
 
 message Profile {


### PR DESCRIPTION
## Summary

This PR fixes a bug where `Overwrite` could not set optional scalar fields to their default values (e.g., `optional bool` to `false`, `optional int32` to `0`, `optional string` to `""`).

Fixes #23

## Problem

The existing logic in `overwrite()` compared field values to the type's default:

```go
if isValid(srcFD, srcVal) && !srcVal.Equal(srcFD.Default()) {
    destRft.Set(srcFD, srcVal)
} else {
    destRft.Clear(srcFD)
}
```

For optional fields, this caused incorrect behavior:

1. Source field is explicitly set to `false` (the default for bool)
2. `srcVal.Equal(srcFD.Default())` returns `true`
3. Code calls `destRft.Clear()` instead of `destRft.Set()`
4. For optional fields, `Clear()` sets the field to `nil` (unset), not `false`
5. Result: Cannot set an optional bool from `true` to `false`

## Solution

For fields with presence semantics (optional, oneof, message), check if the field **is set** using `Has()` rather than comparing the value to the default:

```go
if srcFD.HasPresence() {
    // For fields with presence (optional, oneof, message),
    // check if the field is set rather than comparing to default.
    // This allows setting optional scalars to their default values
    // (e.g., optional bool to false, optional int to 0).
    if srcRft.Has(srcFD) {
        destRft.Set(srcFD, srcVal)
    } else {
        destRft.Clear(srcFD)
    }
} else {
    // For fields without presence, use existing behavior
    if isValid(srcFD, srcVal) && !srcVal.Equal(srcFD.Default()) {
        destRft.Set(srcFD, srcVal)
    } else {
        destRft.Clear(srcFD)
    }
}
```

### Why This Works

For optional fields, there are three distinct states:

| Go Value | Meaning | `Has()` returns |
|----------|---------|-----------------|
| `nil` | Field is not set | `false` |
| `&false` | Field is explicitly set to false | `true` |
| `&true` | Field is explicitly set to true | `true` |

By using `Has()` instead of comparing values, we correctly distinguish between "field is unset" and "field is explicitly set to its default value".

### Fix Scope

`HasPresence()` returns `true` for:
- **Optional fields** (`optional bool`, `optional int32`, etc.)
- **Oneof fields** (fields inside a `oneof` block)
- **Message fields** (any field of message type)

The fix applies to all three, though the issue was most visible for optional scalars (`optional bool` for my team specifically). Message fields already worked correctly due to the `isValid()` check, but this change makes the logic more consistent across all field types with presence.
