### PR TITLE
fix: initialize an unset dest map instead of setting src's

### DIFF
--- a/fmutils.go
+++ b/fmutils.go
@@ -179,6 +179,8 @@ func (mask NestedMask) Prune(msg proto.Message) {
 // Supports scalars, messages, repeated fields, and maps.
 // If the parent of the field is nil message, the parent is initiated before overwriting the field
 // If the field in src is empty value, the field in dest is cleared.
+// A field overwritten as a whole is assigned, not copied, so dest and src end up
+// sharing that message, list or map; clone src first if it is mutated afterwards.
 // Paths are assumed to be valid and normalized otherwise the function may panic.
 func (mask NestedMask) Overwrite(src, dest proto.Message) {
 	mask.overwrite(src.ProtoReflect(), dest.ProtoReflect())

--- a/fmutils.go
+++ b/fmutils.go
@@ -212,11 +212,9 @@ func (mask NestedMask) overwrite(srcRft, destRft protoreflect.Message) {
 			}
 		} else if srcFD.IsMap() && srcFD.Kind() == protoreflect.MessageKind {
 			srcMap := srcRft.Get(srcFD).Map()
-			destMap := destRft.Get(srcFD).Map()
-			if !destMap.IsValid() {
-				destRft.Set(srcFD, protoreflect.ValueOf(srcMap))
-				destMap = destRft.Get(srcFD).Map()
-			}
+			// Mutable initializes an unset dest map in place. Setting src's map instead
+			// would alias it into dest, and panic when src's own map is unset.
+			destMap := destRft.Mutable(srcFD).Map()
 			srcMap.Range(func(mk protoreflect.MapKey, mv protoreflect.Value) bool {
 				if mi, ok := submask[mk.String()]; ok {
 					if i, ok := mv.Interface().(protoreflect.Message); ok && len(mi) > 0 {

--- a/fmutils_test.go
+++ b/fmutils_test.go
@@ -1327,6 +1327,13 @@ func TestOverwrite(t *testing.T) {
 				OptionalString: proto.String(""),
 			},
 		},
+		{
+			name:  "map key path with neither map set does not panic or add an entry",
+			paths: []string{"addresses_by_name.home.number"},
+			src:   &testproto.Profile{},
+			dest:  &testproto.Profile{},
+			want:  &testproto.Profile{},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -1335,6 +1342,21 @@ func TestOverwrite(t *testing.T) {
 				t.Errorf("dest %v, want %v", tt.dest, tt.want)
 			}
 		})
+	}
+}
+
+func TestOverwriteDoesNotAliasSrcMap(t *testing.T) {
+	src := &testproto.Profile{
+		AddressesByName: map[string]*testproto.Address{
+			"home": {Number: "18", PostalCode: "75007"},
+		},
+	}
+	dest := &testproto.Profile{}
+	Overwrite(src, dest, []string{"addresses_by_name.home.number"})
+
+	src.AddressesByName["work"] = &testproto.Address{Number: "2"}
+	if _, ok := dest.AddressesByName["work"]; ok {
+		t.Error("dest shares its map with src: a key added to src showed up in dest")
 	}
 }
 


### PR DESCRIPTION
Hello!

I found a little issue in some unit tests on my side, and thought the fix belonged upstream here -> the map branch of overwrite handed dest src's own map when dest's was unset, which has two consequences:

- dest and src end up sharing one map, so a later write to src's map shows up in dest;
- if src's map is unset too, the value read back is read-only and setting it panics with "map field ... cannot be set with read-only value". A mask like "addresses_by_name.home.number" against two Profiles that carry no map is enough to trigger it.



The "simple" fix is to use `Mutable`, it initializes dest's map in place instead, which is what the list branch just below already does.

Also added the proper unit tests to go with it.